### PR TITLE
Added MaterializedPathBehavior::reorderChildren() method.

### DIFF
--- a/MaterializedPathBehavior.php
+++ b/MaterializedPathBehavior.php
@@ -535,6 +535,20 @@ class MaterializedPathBehavior extends Behavior
         $this->operation = null;
         $this->node      = null;
     }
+    
+    /**
+     * Reorders children with values  of sortAttribute begin from zero.
+     * @throws \Exception
+     */
+    public function reorderChildren()
+    {
+        \Yii::$app->getDb()->transaction(function () {
+            foreach ($this->getChildren()->each() as $i => $child) {
+                $child->{$this->sortAttribute} = ($i - 1) * $this->step;
+                $child->save();
+            }
+        });
+    }
 
     /**
      * @param bool $forInsertNear


### PR DESCRIPTION
This method update value of `$sortAttribut`e for children nodes with `$step` spacing. 
Programm can run this method from queue manager after changing of hierarchy. This will reduce likelihood of a subsequent of changing `$sortAttribute` in user's stream.
It will be useful in high load applications.
